### PR TITLE
Implementing RNG Handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ CPMAddPackage("gh:skypjack/entt@3.14.0")
 # CPMAddPackage("gh:CLIUtils/CLI11@2.4.2")
 # CPMAddPackage("gh:google/googletest@1.15.2")
 
+find_package(GSL REQUIRED)
+
 # If the environment has these set, pull them into proper variables.
 set(CLANG_WARNINGS ${CLANG_COMPILE_FLAGS})
 set(GCC_WARNINGS   ${GCC_COMPILE_FLAGS})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 3.21)
 
 add_subdirectory(sandbox)
 add_subdirectory(basic_flu)
+add_subdirectory(basic_flu_w_vax)

--- a/examples/basic_flu_w_vax/CMakeLists.txt
+++ b/examples/basic_flu_w_vax/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.21)
+
+add_executable(basic_flu_vax_model main.cpp)
+
+target_link_libraries(basic_flu_vax_model PRIVATE xlamb)
+
+set_target_properties(basic_flu_vax_model
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/examples/basic_flu_w_vax/main.cpp
+++ b/examples/basic_flu_w_vax/main.cpp
@@ -1,0 +1,24 @@
+#include <xlamb/xlamb.hpp>
+#include "model.hpp"
+
+int main() {
+    xlamb::Simulator sim;
+    sim.bind(setup, simulate, report);
+    return sim.run();
+
+/* API PLANNING
+
+    # in user main.cpp
+    int main(int argc, char* argv[]) {
+        xlamb::simulator app(argc, argv);
+        return app.run(setup, simulate, report);
+    }
+
+    # xlamb::simulator::run() plan
+      # read config files
+      # read from database (single or batch)
+      # set up/run simulation(s)
+      # calculate metrics + save to file/database
+
+*/
+}

--- a/examples/basic_flu_w_vax/model.hpp
+++ b/examples/basic_flu_w_vax/model.hpp
@@ -97,11 +97,11 @@ void tally_infections_by_vax(xlamb::Context& context) {
     std::unordered_map<VaccinationStatus, size_t> inf_ledger;
     inf_ledger[VaccinationStatus::VAXD]   = 0;
     inf_ledger[VaccinationStatus::UNVAXD] = 0;
-    size_t num_vaxd = 0;
+
     for (const auto [ent, s, ih, vh] : context.each_entity_with<Susceptibility, InfectionHistory, VaccinationHistory>()) {
         const auto vaccinated = vh.is_vaccinated();
         const auto infected   = ih.has_been_infected();
-        if (vaccinated) num_vaxd++;
+
         if (infected) {
             if (vaccinated) {
                 inf_ledger[VaccinationStatus::VAXD]++;
@@ -111,7 +111,6 @@ void tally_infections_by_vax(xlamb::Context& context) {
         }
     }
 
-    XLAMB_INFO("Num vaxd:       {}", num_vaxd);
     XLAMB_INFO("Num vax infs:   {}", inf_ledger[VaccinationStatus::VAXD]);
     XLAMB_INFO("Num unvax infs: {}", inf_ledger[VaccinationStatus::UNVAXD]);
 }

--- a/examples/sandbox/model.hpp
+++ b/examples/sandbox/model.hpp
@@ -3,14 +3,10 @@
 
 // PLACE NECESSARY INCLUDES HERE
 #include <unordered_map>
-#include <random>
 
 //------------------------------------------------------------------------------
 // Place model-specific code below to be called in xlamb simulator fucntions.
 //------------------------------------------------------------------------------
-
-std::default_random_engine rng(0);
-std::uniform_real_distribution<> unif(0.0, 1.0);
 
 enum class Strain {
     FLU,
@@ -66,27 +62,33 @@ void generate_synth_pop(xlamb::Context& context, const size_t pop_size) {
 }
 
 void random_vaccination_campaign(xlamb::Context& context, const double pr_vax, const Vaccination& vax) {
+    const auto rng = context.get_rng();
+
     for (auto [ent, vh, s] : context.each_entity_with<VaccinationHistory, Susceptibility>()) {
-        if (unif(rng) < pr_vax) {
+        if (rng->unif("VAX") < pr_vax) {
             vh.vax_hist.push_back(vax);
             s.current_susceptibility.at(Strain::FLU) *= 1 - vax.efficacy.at(Strain::FLU);
         }
     }
 }
 
-void attempt_infection_given_exposure(Susceptibility& s, InfectionHistory& ih, const size_t time) {
+void attempt_infection_given_exposure(xlamb::Context& context, Susceptibility& s, InfectionHistory& ih, const size_t time) {
+    const auto rng = context.get_rng();
     const auto current_suscep = s.current_susceptibility[Strain::FLU];
-    if (unif(rng) < static_cast<double>(current_suscep)) {
+
+    if (rng->unif("INF") < static_cast<double>(current_suscep)) {
         ih.inf_hist.push_back({time, Strain::FLU});
         s.current_susceptibility[Strain::FLU] = 0.0;
     }
 }
 
 void transmission(xlamb::Context& context, const size_t time) {
+    const auto rng = context.get_rng();
     const double pr_exp = context.get_entity("flu_pathogen").get_component<Pathogen>().pr_exposure;
+
     for (auto [ent, s, ih] : context.each_entity_with<Susceptibility, InfectionHistory>()) {
-        if (unif(rng) < pr_exp) {
-            attempt_infection_given_exposure(s, ih, time);
+        if (rng->unif("INF") < pr_exp) {
+            attempt_infection_given_exposure(context, s, ih, time);
         }
     }
 }
@@ -95,9 +97,11 @@ void tally_infections_by_vax(xlamb::Context& context) {
     std::unordered_map<VaccinationStatus, size_t> inf_ledger;
     inf_ledger[VaccinationStatus::VAXD]   = 0;
     inf_ledger[VaccinationStatus::UNVAXD] = 0;
+
     for (const auto [ent, s, ih, vh] : context.each_entity_with<Susceptibility, InfectionHistory, VaccinationHistory>()) {
         const auto vaccinated = vh.is_vaccinated();
         const auto infected   = ih.has_been_infected();
+
         if (infected) {
             if (vaccinated) {
                 inf_ledger[VaccinationStatus::VAXD]++;
@@ -127,6 +131,11 @@ void tally_infections_by_vax(xlamb::Context& context) {
 //------------------------------------------------------------------------------
 
 void setup(xlamb::Context& context) {
+    auto rng = context.get_rng();
+    rng->create_generator("INF");
+    rng->create_generator("VAX");
+    rng->set_seed(0);
+
     auto flu = context.create_entity("flu_pathogen");
     flu.add_component<Pathogen>(Strain::FLU, 0.01);
 

--- a/include/xlamb/context.hpp
+++ b/include/xlamb/context.hpp
@@ -17,13 +17,14 @@ class Context {
     Context() : rng(std::make_unique<RNG_Handler>()) {};
     ~Context() = default;
 
-    Entity create_entity(const std::string = "default_entity");
-    void destroy_entity(Entity e);
+    Entity create_entity(const std::string name = "default_entity");
+
+    void destroy_entity(Entity& e);
 
     template<typename T>
     void clear_component() { registry.clear<T>(); }
 
-    Entity get_entity(std::string);
+    Entity get_entity(std::string name);
 
     template<typename... Ts>
     auto view_entities_with() { return registry.view<Ts...>(); }

--- a/include/xlamb/context.hpp
+++ b/include/xlamb/context.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <unordered_map>
+#include <string>
+#include <memory>
 
 #include <entt/entt.hpp>
+
+#include <xlamb/rng_handler.hpp>
 
 namespace xlamb {
 
@@ -10,8 +14,8 @@ class Entity;
 
 class Context {
   public:
-    Context();
-    ~Context();
+    Context() : rng(std::make_unique<RNG_Handler>()) {};
+    ~Context() = default;
 
     Entity create_entity(const std::string = "default_entity");
     void destroy_entity(Entity e);
@@ -29,9 +33,13 @@ class Context {
 
     void clear_registry();
 
+    RNG_Handler* get_rng();
+
   private:
     entt::registry registry;
     std::unordered_map<std::string, entt::entity> entity_lookup;
+
+    std::unique_ptr<RNG_Handler> rng;
 
     friend class Entity;
 };

--- a/include/xlamb/logger.hpp
+++ b/include/xlamb/logger.hpp
@@ -14,12 +14,12 @@ struct Log;
 
 class Logger {
   public:
-    Logger(const Logger&)            = delete;
-    Logger& operator=(const Logger&) = delete;
+    Logger(const Logger& other)            = delete;
+    Logger& operator=(const Logger& other) = delete;
 
     static Logger& get();
 
-    void set_console_printing(bool);
+    void set_console_printing(bool console);
 
     template<typename... Args>
     void trace(Args&&... args) {
@@ -56,8 +56,6 @@ class Logger {
     ~Logger() = default;
 
     bool console_logs;
-
-    void store_log(log_level, std::string);
 
     static std::shared_ptr<spdlog::logger> spdlogger;
 };

--- a/include/xlamb/rng_handler.hpp
+++ b/include/xlamb/rng_handler.hpp
@@ -20,9 +20,9 @@ class RNG_Handler {
 
     void set_seed(const std::string&, seed_type);
 
-    double draw(const std::string&);
+    double unif(const std::string&);
 
-    double inspect_next_draw(const std::string&);
+    double inspect_next_unif(const std::string&);
 
   private:
     bool generator_exists(const std::string&);

--- a/include/xlamb/rng_handler.hpp
+++ b/include/xlamb/rng_handler.hpp
@@ -14,18 +14,18 @@ class RNG_Handler {
     RNG_Handler() = default;
     ~RNG_Handler();
 
-    void create_generator(const std::string&);
+    void create_generator(const std::string& key);
 
-    void set_seed(seed_type);
+    void set_seed(seed_type seed);
 
-    void set_seed(const std::string&, seed_type);
+    void set_seed(const std::string& key, seed_type seed);
 
-    double unif(const std::string&);
+    double unif(const std::string& key);
 
-    double inspect_next_unif(const std::string&);
+    double inspect_next_unif(const std::string& key);
 
   private:
-    bool generator_exists(const std::string&);
+    bool generator_exists(const std::string& key);
 
     std::unordered_map<std::string, gsl_rng*> generators;
 };

--- a/include/xlamb/rng_handler.hpp
+++ b/include/xlamb/rng_handler.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <unordered_map>
+#include <string>
+
+#include <gsl/gsl_rng.h>
+
+namespace xlamb {
+
+using seed_type = unsigned long int;
+
+class RNG_Handler {
+  public:
+    RNG_Handler() = default;
+    ~RNG_Handler();
+
+    void create_generator(const std::string&);
+
+    void set_seed(seed_type);
+
+    void set_seed(const std::string&, seed_type);
+
+    double draw(const std::string&);
+
+    double inspect_next_draw(const std::string&);
+
+  private:
+    bool generator_exists(const std::string&);
+
+    std::unordered_map<std::string, gsl_rng*> generators;
+};
+
+} // namespace xlamb

--- a/include/xlamb/simulator.hpp
+++ b/include/xlamb/simulator.hpp
@@ -12,9 +12,9 @@ class Simulator {
     Simulator() = default;
     ~Simulator() = default;
 
-    void bind(std::function<void(xlamb::Context&)>,
-              std::function<void(xlamb::Context&)>,
-              std::function<void(xlamb::Context&)>);
+    void bind(std::function<void(xlamb::Context&)> f_setup,
+              std::function<void(xlamb::Context&)> f_sim,
+              std::function<void(xlamb::Context&)> f_report);
 
     int run();
 

--- a/include/xlamb/utility.hpp
+++ b/include/xlamb/utility.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <vector>
+
+namespace xlamb {
+
+namespace util {
+
+extern double logistic(const double log_odds);
+
+extern double logit(const double prob);
+
+extern double exp_decay_rate_from_half_life(const double half_life);
+
+extern double exp_decay(const double rate, const double time);
+
+} // namespace util
+  
+} // namespace xlamb

--- a/include/xlamb/xlamb.hpp
+++ b/include/xlamb/xlamb.hpp
@@ -8,3 +8,4 @@
 #include <xlamb/context.hpp>
 
 #include <xlamb/rng_handler.hpp>
+#include <xlamb/utility.hpp>

--- a/include/xlamb/xlamb.hpp
+++ b/include/xlamb/xlamb.hpp
@@ -6,3 +6,5 @@
 
 #include <xlamb/entity.hpp>
 #include <xlamb/context.hpp>
+
+#include <xlamb/rng_handler.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
   context.cpp
   simulator.cpp
   rng_handler.cpp
+  utility.cpp
   ${HEADER_LIST}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,12 +8,13 @@ add_library(
   entity.cpp
   context.cpp
   simulator.cpp
+  rng_handler.cpp
   ${HEADER_LIST}
 )
 
 target_include_directories(xlamb PUBLIC ${xlamb_SOURCE_DIR}/include)
 
-target_link_libraries(xlamb PUBLIC spdlog EnTT)
+target_link_libraries(xlamb PUBLIC spdlog EnTT GSL::gsl)
 
 # IDEs should put the headers in a nice place
 source_group(

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -6,10 +6,6 @@
 
 namespace xlamb {
 
-Context::Context() {}
-
-Context::~Context() {}
-
 Entity Context::create_entity(const std::string name) {
     Entity e = {registry.create(), this};
     auto& tag = e.add_component<TagComponent>();
@@ -28,5 +24,7 @@ Entity Context::get_entity(std::string name) {
 }
 
 void Context::clear_registry() { registry.clear(); }
+
+RNG_Handler* Context::get_rng() { return rng.get(); }
 
 } // namespace xlamb

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -15,7 +15,7 @@ Entity Context::create_entity(const std::string name) {
     return e;
 }
 
-void Context::destroy_entity(Entity e) {
+void Context::destroy_entity(Entity& e) {
     registry.destroy(e.entity_handle);
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -5,11 +5,11 @@
 
 namespace xlamb {
 
-struct Log {
-    Log(log_level l, std::string s) : level(l), entry(s) {}
-    log_level level;
-    std::string entry;
-};
+// struct Log {
+//     Log(log_level l, std::string s) : level(l), entry(s) {}
+//     log_level level;
+//     std::string entry;
+// };
 
 std::shared_ptr<spdlog::logger> Logger::spdlogger;
 

--- a/src/rng_handler.cpp
+++ b/src/rng_handler.cpp
@@ -32,7 +32,7 @@ void RNG_Handler::set_seed(const std::string& key, seed_type seed) {
     }
 }
 
-double RNG_Handler::draw(const std::string& key) {
+double RNG_Handler::unif(const std::string& key) {
     if (generator_exists(key)) {
         return gsl_rng_uniform(generators.at(key));
     } else {
@@ -41,7 +41,7 @@ double RNG_Handler::draw(const std::string& key) {
     }
 }
 
-double RNG_Handler::inspect_next_draw(const std::string& key) {
+double RNG_Handler::inspect_next_unif(const std::string& key) {
     if (generator_exists(key)) {
         auto rng_copy = gsl_rng_clone(generators.at(key));
         const double next_draw = gsl_rng_uniform(rng_copy);

--- a/src/rng_handler.cpp
+++ b/src/rng_handler.cpp
@@ -1,0 +1,60 @@
+#include <xlamb/rng_handler.hpp>
+
+#include <xlamb/logger.hpp>
+
+namespace xlamb {
+
+RNG_Handler::~RNG_Handler() {
+    for (auto [key, rng] : generators) {
+        gsl_rng_free(rng);
+    }
+}
+
+void RNG_Handler::create_generator(const std::string& key) {
+    if (not generator_exists(key)) {
+        generators[key] = gsl_rng_alloc(gsl_rng_mt19937);
+    } else {
+        XLAMB_ERROR("Attempting to overwrite existing RNG ({}).", key);
+    }
+}
+
+void RNG_Handler::set_seed(seed_type seed) {
+    for (auto [key, rng] : generators) {
+        gsl_rng_set(rng, seed);
+    }
+}
+
+void RNG_Handler::set_seed(const std::string& key, seed_type seed) {
+    if (generator_exists(key)) {
+        gsl_rng_set(generators.at(key), seed);
+    } else {
+        XLAMB_ERROR("Attempting to set seed for nonexistant RNG ({}).", key);
+    }
+}
+
+double RNG_Handler::draw(const std::string& key) {
+    if (generator_exists(key)) {
+        return gsl_rng_uniform(generators.at(key));
+    } else {
+        XLAMB_ERROR("Attempting to draw from nonexistant RNG ({}).", key);
+        return -1;
+    }
+}
+
+double RNG_Handler::inspect_next_draw(const std::string& key) {
+    if (generator_exists(key)) {
+        auto rng_copy = gsl_rng_clone(generators.at(key));
+        const double next_draw = gsl_rng_uniform(rng_copy);
+        gsl_rng_free(rng_copy);
+        return next_draw;
+    } else {
+        XLAMB_ERROR("Attempting to inspect a nonexistant RNG ({}).", key);
+        return -1;
+    }
+}
+
+bool RNG_Handler::generator_exists(const std::string& key) {
+    return generators.count(key) == 1;
+}
+
+} // namespace xlamb

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,0 +1,28 @@
+#include <xlamb/utility.hpp>
+
+#include <cmath>
+
+namespace xlamb {
+
+namespace util {
+
+double logistic(const double log_odds) {
+    return 1.0 / (1.0 + std::exp(-1.0 * log_odds));
+}
+
+double logit(const double prob) {
+    return std::log(prob / (1.0 - prob));
+}
+
+double exp_decay_rate_from_half_life(const double half_life) {
+    return std::log(2.0) / half_life;
+}
+
+double exp_decay(const double rate, const double time) {
+    return std::exp(-1.0 * rate * time);
+}
+
+} // namespace util
+
+
+} // namespace xlamb


### PR DESCRIPTION
The context now owns a pointer to an RNG Handler that allows the user to create nicknamed GSL RNG engines (currently hardcoded to use GSL's `gsl_rng_mt19937`). Each named RNG can generate uniform draws and can have its next draw safely inspected without altering the RNG state (for debugging).

**Features:**
Create a RNG engine with a key/name
```cpp
auto rng = context.get_rng();
rng->create_generator("def");
```

Set the seed of a single named RNG
```cpp
rng->set_seed("def", 0);
```

Set the seed of all instantiated RNGs
```cpp
rng->set_seed(0);
```

Draw uniformly from RNG (using `gsl_rng_uniform()`)
```cpp
rng->unif("def")
```