### PR TITLE
API for EnTT's context any map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(XLAMB_PEDANTIC_WARNINGS)
     -Wpedantic # warn if non-standard C++ is used
     -Wconversion # warn on type conversions that may lose data
     -Wsign-conversion # warn on sign conversions
-    -Wnull-dereference # warn if a null dereference is detected
+    # -Wnull-dereference # warn if a null dereference is detected
     -Wdouble-promotion # warn if float is implicit promoted to double
     -Wformat=2 # warn on security issues around functions that format output (ie printf)
     -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation

--- a/include/xlamb/context.hpp
+++ b/include/xlamb/context.hpp
@@ -14,7 +14,7 @@ class Entity;
 
 class Context {
   public:
-    Context() : rng(std::make_unique<RNG_Handler>()) {};
+    Context();
     ~Context() = default;
 
     Entity create_entity(const std::string name = "default_entity");
@@ -32,6 +32,24 @@ class Context {
     template<typename... Ts>
     auto each_entity_with() { return registry.view<Ts...>().each(); }
 
+    template<typename T, typename... Args>
+    T& attach(Args&&... args) {
+        T& item = registry.ctx().emplace<T>(std::forward<Args>(args)...);
+        return item;
+    }
+
+    template<typename T>
+    T* find() { return registry.ctx().find<T>(); }
+
+    template<typename T>
+    T& get() { return registry.ctx().get<T>(); }
+
+    template<typename T>
+    bool has() { return registry.ctx().contains<T>(); }
+
+    template<typename T>
+    void erase() { return registry.ctx().erase<T>(); }
+
     void clear_registry();
 
     RNG_Handler* get_rng();
@@ -39,8 +57,6 @@ class Context {
   private:
     entt::registry registry;
     std::unordered_map<std::string, entt::entity> entity_lookup;
-
-    std::unique_ptr<RNG_Handler> rng;
 
     friend class Entity;
 };

--- a/include/xlamb/context.hpp
+++ b/include/xlamb/context.hpp
@@ -47,7 +47,7 @@ class Context {
     bool has() { return registry.ctx().contains<T>(); }
 
     template<typename T>
-    void erase() { return registry.ctx().erase<T>(); }
+    void erase() { registry.ctx().erase<T>(); }
 
     void clear_registry();
 

--- a/include/xlamb/context.hpp
+++ b/include/xlamb/context.hpp
@@ -2,7 +2,6 @@
 
 #include <unordered_map>
 #include <string>
-#include <memory>
 
 #include <entt/entt.hpp>
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,5 +1,7 @@
 #include <xlamb/context.hpp>
 
+#include <memory>
+
 #include <entt/entt.hpp>
 
 #include <xlamb/entity.hpp>

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -31,12 +31,9 @@ Entity Context::get_entity(std::string name) {
 
 void Context::clear_registry() { registry.clear(); }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnull-dereference"
 RNG_Handler* Context::get_rng() {
     auto& rng_handler = get<std::unique_ptr<RNG_Handler>>();
     return (rng_handler) ? rng_handler.get() : nullptr;
 }
-#pragma GCC diagnostic pop
 
 } // namespace xlamb

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -31,9 +31,12 @@ Entity Context::get_entity(std::string name) {
 
 void Context::clear_registry() { registry.clear(); }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
 RNG_Handler* Context::get_rng() {
     auto& rng_handler = get<std::unique_ptr<RNG_Handler>>();
     return (rng_handler) ? rng_handler.get() : nullptr;
 }
+#pragma GCC diagnostic pop
 
 } // namespace xlamb

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -31,6 +31,9 @@ Entity Context::get_entity(std::string name) {
 
 void Context::clear_registry() { registry.clear(); }
 
-RNG_Handler* Context::get_rng() { return get<std::unique_ptr<RNG_Handler>>().get(); }
+RNG_Handler* Context::get_rng() {
+    auto& rng_handler = get<std::unique_ptr<RNG_Handler>>();
+    return (rng_handler) ? rng_handler.get() : nullptr;
+}
 
 } // namespace xlamb

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -6,6 +6,10 @@
 
 namespace xlamb {
 
+Context::Context() {
+    attach<std::unique_ptr<RNG_Handler>>(std::make_unique<RNG_Handler>());
+}
+
 Entity Context::create_entity(const std::string name) {
     Entity e = {registry.create(), this};
     auto& tag = e.add_component<TagComponent>();
@@ -25,6 +29,6 @@ Entity Context::get_entity(std::string name) {
 
 void Context::clear_registry() { registry.clear(); }
 
-RNG_Handler* Context::get_rng() { return rng.get(); }
+RNG_Handler* Context::get_rng() { return get<std::unique_ptr<RNG_Handler>>().get(); }
 
 } // namespace xlamb

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(tests
   test-context_entity_handling.cpp
   test-context_views.cpp
   test-context_rng.cpp
+  test-context_any_map.cpp
 )
 target_link_libraries(tests xlamb gtest gtest_main)
 

--- a/test/test-context_any_map.cpp
+++ b/test/test-context_any_map.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include <xlamb/xlamb.hpp>
+
+TEST(context_any_map, attach_item) {
+    auto context = xlamb::Context();
+
+    struct Foo {
+        int a = 1;
+    };
+
+    const auto& foo = context.attach<Foo>();
+    EXPECT_EQ(foo.a, 1);
+}
+
+TEST(context_any_map, get_item) {
+    auto context = xlamb::Context();
+
+    struct Foo {
+        int a = 1;
+    };
+
+    context.attach<Foo>();
+
+    const auto& foo = context.get<Foo>();
+    EXPECT_EQ(foo.a, 1);
+}
+
+TEST(context_any_map, find_item) {
+    auto context = xlamb::Context();
+
+    struct Foo {
+        int a = 1;
+    };
+
+    context.attach<Foo>();
+
+    const auto foo = context.find<Foo>();
+    EXPECT_EQ(foo->a, 1);
+}
+
+TEST(context_any_map, has_item) {
+    auto context = xlamb::Context();
+
+    struct Foo {
+        int a = 1;
+    };
+
+    context.attach<Foo>();
+
+    EXPECT_TRUE(context.has<Foo>());
+}
+
+TEST(context_any_map, edit_item) {
+    auto context = xlamb::Context();
+
+    struct Foo {
+        int a = 1;
+    };
+
+    auto& foo = context.attach<Foo>();
+    for (int i = 0; i < 10; ++i) {
+        foo.a = i;
+    }
+    
+    EXPECT_EQ(context.get<Foo>().a, 9);
+}
+
+TEST(context_any_map, erase_item) {
+    auto context = xlamb::Context();
+
+    struct Foo {
+        int a = 1;
+    };
+
+    context.attach<Foo>();
+
+    EXPECT_TRUE(context.has<Foo>());
+    EXPECT_EQ(context.get<Foo>().a, 1);
+
+    context.erase<Foo>();
+    EXPECT_FALSE(context.has<Foo>());
+}


### PR DESCRIPTION
Now storing xlamb modules in the any map implemented in EnTT's registry. A simple API wrapper is also provided to allow users to store their own items in this map, get/find them, and erase them.